### PR TITLE
Allow React 17 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0-rc || ^16.0.0-rc"
+    "react": "0.14.x || ^15.0.0-rc || ^16.0.0-rc || ^17.0.0-rc"
   },
   "scripts": {
     "build": "nwb build-react-component",


### PR DESCRIPTION
I should probably find an alternative for my gist-rendering needs, but in case this repo is still monitored, I'm getting tired of this npm error complaining about peer dependencies when I try to use this with React 17.

![2021-10-30_07-35](https://user-images.githubusercontent.com/5317080/139537541-9de553dc-1bdf-4fcc-8bd7-a21e65efd973.png)

I've looked through the [list of breaking changes](https://reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation) in React 17, and I'm _pretty_ sure none of them affect this package.