### PR TITLE
chore: Allow React 18 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0-rc || ^16.0.0-rc || ^17.0.0-rc"
+    "react": "0.14.x || ^15.0.0-rc || ^16.0.0-rc || ^17.0.0-rc || ^18.0.0-rc"
   },
   "scripts": {
     "build": "nwb build-react-component",


### PR DESCRIPTION
Allow react-gist to work with React18